### PR TITLE
Fix utf8 on subject and sender

### DIFF
--- a/eboks-mailer.py
+++ b/eboks-mailer.py
@@ -102,8 +102,8 @@ for msg in msgs.select("li"):
 
         msgid = msg.a["href"].split("'")[1]
         date = msg.select("span.recieved")[0].text
-        sender = msg.select("span.sender")[0].text
-        subject = msg.select("span.title")[0].text
+        sender = msg.select("span.sender")[0].text.encode("utf8")
+        subject = msg.select("span.title")[0].text.encode("utf8")
 
         print "[*] Getting documents for:", subject
 


### PR DESCRIPTION
Fixes the following error message:
[_] Getting documents for: Traceback (most recent call last):
 File "/opt/eboks-mailer/eboks-mailer.py", line 108, in <module>
   print "[_] Getting documents for:", subject
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe6' in position 4: ordinal not in range(128)
